### PR TITLE
fix: improve TruffleHog scanner configuration

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -129,8 +129,8 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: ${{ github.event.repository.default_branch }}
-        head: HEAD
+        base: ${{ github.event.before || (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || '' }}
+        head: ${{ github.event.after || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || 'HEAD' }}
         extra_args: --debug --only-verified
 
   codeql-analysis:


### PR DESCRIPTION
## Summary
- Fixed TruffleHog scanner configuration to properly handle different GitHub event types
- Prevents workflow failures when base SHA is not available
- Correctly detects base/head SHAs for pull_request and push events

## Changes
- Updated `.github/workflows/security.yml` to use proper SHA detection
- Added fallbacks for when base SHA is not available (e.g., initial commits)

## Test plan
- [x] Security workflow should run without errors on push events
- [x] Security workflow should run without errors on pull requests
- [x] TruffleHog scanner should properly detect secrets between commits